### PR TITLE
Generic Voter Weight Plugin: Add client-side voter weight calculations

### DIFF
--- a/VoterWeightPlugins/utils.ts
+++ b/VoterWeightPlugins/utils.ts
@@ -1,0 +1,9 @@
+export const reduceAsync = async <TElem, TOut = TElem>(
+    arr: TElem[],
+    reducer: (
+        acc: Awaited<TOut>,
+        item: TElem
+    ) => Promise<TOut>,
+    initialValue: TOut
+): Promise<TOut> =>
+    arr.reduce(async (acc, item) => reducer(await acc, item), Promise.resolve(initialValue))

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "@sentry/nextjs": "7.81.1",
     "@solana-mobile/wallet-adapter-mobile": "2.0.0",
     "@solana/buffer-layout": "4.0.0",
-    "@solana/governance-program-library": "npm:@civic/governance-program-library@0.18.2-beta.8",
+    "@solana/governance-program-library": "npm:@civic/governance-program-library@0.18.2-beta.10",
     "@solana/spl-account-compression": "~0.2.0",
     "@solana/spl-governance": "0.3.28",
     "@solana/spl-token": "0.1.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4292,10 +4292,10 @@
   dependencies:
     buffer "~6.0.3"
 
-"@solana/governance-program-library@npm:@civic/governance-program-library@0.18.2-beta.8":
-  version "0.18.2-beta.8"
-  resolved "https://registry.yarnpkg.com/@civic/governance-program-library/-/governance-program-library-0.18.2-beta.8.tgz#2eaecd8c0c92237f319adf8d873f3f35401df107"
-  integrity sha512-IJ334U0UjxwUr1XIbZ/B6NlQc0cBoexgejO+GHTE+eBVies8V2As7BMu8JkM658oe66wdriz8rm8AA/3VJgXJA==
+"@solana/governance-program-library@npm:@civic/governance-program-library@0.18.2-beta.10":
+  version "0.18.2-beta.10"
+  resolved "https://registry.yarnpkg.com/@civic/governance-program-library/-/governance-program-library-0.18.2-beta.10.tgz#e6c0ac19301161d67471daba6844cafa27e64b74"
+  integrity sha512-1lCU6X1npr2U7tWuiK/ZlTZCiVUKsJoFED+aYWQmhHLGg9p9QWAZq4qf34qukPNLAZHcP7p2lEKomDiH1yd9gA==
   dependencies:
     "@coral-xyz/anchor" "^0.28.0"
     "@identity.com/solana-gateway-ts" "^0.12.0"


### PR DESCRIPTION
Voter weights are now calculated client-side by iterating through the plugins, taking the token owner record (aka "vanilla vote weight") as the input.